### PR TITLE
Enable .env loading for translation

### DIFF
--- a/get_data/process.py
+++ b/get_data/process.py
@@ -15,11 +15,15 @@ NLP处理模块
 
 import os
 import logging
+from dotenv import load_dotenv
 from openai import OpenAI
 from tqdm import tqdm
 import time
 import random
 from datetime import datetime
+
+# 加载 .env 文件中的环境变量
+load_dotenv()
 
 # 导入数据库工具类
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ feedparser
 beautifulsoup4
 openai
 tqdm
+python-dotenv
 python-dateutil
 soupsieve
 requests


### PR DESCRIPTION
## Summary
- load `.env` variables in `get_data/process.py`
- require `python-dotenv`

## Testing
- `python -m py_compile get_data/process.py`


------
https://chatgpt.com/codex/tasks/task_e_6840e9ac858083339170a02f3d1b94c7